### PR TITLE
Add DurationValue

### DIFF
--- a/src/values.js
+++ b/src/values.js
@@ -160,6 +160,38 @@ export class FloatValue extends Value {
   }
 }
 
-export {
-  process,
-};
+export class DurationValue extends IntegerValue {
+  static SECOND = 1000;
+  static MINUTE = 60 * DurationValue.SECOND;
+  static HOUR = 60 * DurationValue.MINUTE;
+  static DAY = 24 * DurationValue.HOUR;
+
+  toJS(value) {
+    let quantity, unit;
+
+    try {
+      [, quantity, unit] = value.match(/^([0-9]*)([smhd]?)$/i);
+    } catch (err) {
+      throw new ValueError('Cannot interpret value.');
+    }
+
+    // Convert quantity to an integer
+    quantity = super.toJS(quantity);
+
+    // Normalize unit
+    unit = unit.toLowerCase();
+
+    let multiplier = 1;
+    if (unit === 's') {
+      multiplier = DurationValue.SECOND;
+    } else if (unit === 'm') {
+      multiplier = DurationValue.MINUTE;
+    } else if (unit === 'h') {
+      multiplier = DurationValue.HOUR;
+    } else if (unit === 'd') {
+      multiplier = DurationValue.DAY;
+    }
+
+    return quantity * multiplier;
+  }
+}

--- a/src/values.js
+++ b/src/values.js
@@ -181,9 +181,7 @@ export class DurationValue extends IntegerValue {
       ...minutesUnits,
       ...hoursUnits,
       ...daysUnits,
-    ]
-      .reduce((reduced, current) => `${reduced}|${current}`, '')
-      .slice(1);
+    ].reduce((reduced, current) => `${reduced}|${current}`);
 
     const re = new RegExp(`^([0-9]*)\\s*((?:${unitsPatterns})?)$`, 'i');
 

--- a/src/values.js
+++ b/src/values.js
@@ -169,8 +169,26 @@ export class DurationValue extends IntegerValue {
   toJS(value) {
     let quantity, unit;
 
+    const millisecondsUnits = ['ms', 'millisecond', 'milliseconds'];
+    const secondsUnits = ['s', 'sec', 'secs', 'second', 'seconds'];
+    const minutesUnits = ['m', 'min', 'mins', 'minute', 'minutes'];
+    const hoursUnits = ['h', 'hr', 'hrs', 'hour', 'hours'];
+    const daysUnits = ['d', 'day', 'days'];
+
+    const unitsPatterns = [
+      ...millisecondsUnits,
+      ...secondsUnits,
+      ...minutesUnits,
+      ...hoursUnits,
+      ...daysUnits,
+    ]
+      .reduce((reduced, current) => `${reduced}|${current}`, '')
+      .slice(1);
+
+    const re = new RegExp(`^([0-9]*)\\s*((?:${unitsPatterns})?)$`, 'i');
+
     try {
-      [, quantity, unit] = value.match(/^([0-9]*)([smhd]?)$/i);
+      [, quantity, unit] = value.match(re);
     } catch (err) {
       throw new ValueError('Cannot interpret value.');
     }
@@ -182,13 +200,13 @@ export class DurationValue extends IntegerValue {
     unit = unit.toLowerCase();
 
     let multiplier = 1;
-    if (unit === 's') {
+    if (secondsUnits.includes(unit)) {
       multiplier = DurationValue.SECOND;
-    } else if (unit === 'm') {
+    } else if (minutesUnits.includes(unit)) {
       multiplier = DurationValue.MINUTE;
-    } else if (unit === 'h') {
+    } else if (hoursUnits.includes(unit)) {
       multiplier = DurationValue.HOUR;
-    } else if (unit === 'd') {
+    } else if (daysUnits.includes(unit)) {
       multiplier = DurationValue.DAY;
     }
 

--- a/tests/values.test.js
+++ b/tests/values.test.js
@@ -328,35 +328,111 @@ describe('values.test.js', () => {
       });
 
       it('returns the value if there is no unit', () => {
-        let v = newValue('INT');
+        const v = newValue('INT');
         assert.deepStrictEqual(v.value, 23);
       });
 
+      it('returns the value if set in milliseconds', () => {
+        stubbedEnv.DV_MILLISECONDS = '2ms';
+        let v = newValue('DV_MILLISECONDS');
+        assert.deepStrictEqual(v.value, 2);
+
+        stubbedEnv.DV_MILLISECONDS = '1 millisecond';
+        v = newValue('DV_MILLISECONDS');
+        assert.deepStrictEqual(v.value, 1);
+
+        stubbedEnv.DV_MILLISECONDS = '3 milliseconds';
+        v = newValue('DV_MILLISECONDS');
+        assert.deepStrictEqual(v.value, 3);
+
+        delete stubbedEnv.DV_MILLISECONDS;
+      });
+
       it('returns the value if set in seconds', () => {
-        stubbedEnv.DV_SECONDS = '4s';
-        const v = newValue('DV_SECONDS');
-        assert.deepStrictEqual(v.value, 4000);
+        stubbedEnv.DV_SECONDS = '2s';
+        let v = newValue('DV_SECONDS');
+        assert.deepStrictEqual(v.value, 2000);
+
+        stubbedEnv.DV_SECONDS = '1 sec';
+        v = newValue('DV_SECONDS');
+        assert.deepStrictEqual(v.value, 1000);
+
+        stubbedEnv.DV_SECONDS = '2 secs';
+        v = newValue('DV_SECONDS');
+        assert.deepStrictEqual(v.value, 2000);
+
+        stubbedEnv.DV_SECONDS = '1 second';
+        v = newValue('DV_SECONDS');
+        assert.deepStrictEqual(v.value, 1000);
+
+        stubbedEnv.DV_SECONDS = '2 seconds';
+        v = newValue('DV_SECONDS');
+        assert.deepStrictEqual(v.value, 2000);
+
         delete stubbedEnv.DV_SECONDS;
       });
 
       it('returns the value if set in minutes', () => {
-        stubbedEnv.DV_MINUTES = '1m';
-        const v = newValue('DV_MINUTES');
+        stubbedEnv.DV_MINUTES = '2m';
+        let v = newValue('DV_MINUTES');
+        assert.deepStrictEqual(v.value, 120000);
+
+        stubbedEnv.DV_MINUTES = '1 min';
+        v = newValue('DV_MINUTES');
         assert.deepStrictEqual(v.value, 60000);
+
+        stubbedEnv.DV_MINUTES = '2 mins';
+        v = newValue('DV_MINUTES');
+        assert.deepStrictEqual(v.value, 120000);
+
+        stubbedEnv.DV_MINUTES = '1 minute';
+        v = newValue('DV_MINUTES');
+        assert.deepStrictEqual(v.value, 60000);
+
+        stubbedEnv.DV_MINUTES = '2 minutes';
+        v = newValue('DV_MINUTES');
+        assert.deepStrictEqual(v.value, 120000);
+
         delete stubbedEnv.DV_MINUTES;
       });
 
       it('returns the value if set in hours', () => {
-        stubbedEnv.DV_HOURS = '1h';
-        const v = newValue('DV_HOURS');
+        stubbedEnv.DV_HOURS = '2h';
+        let v = newValue('DV_HOURS');
+        assert.deepStrictEqual(v.value, 7200000);
+
+        stubbedEnv.DV_HOURS = '1 hr';
+        v = newValue('DV_HOURS');
         assert.deepStrictEqual(v.value, 3600000);
+
+        stubbedEnv.DV_HOURS = '2 hrs';
+        v = newValue('DV_HOURS');
+        assert.deepStrictEqual(v.value, 7200000);
+
+        stubbedEnv.DV_HOURS = '1 hour';
+        v = newValue('DV_HOURS');
+        assert.deepStrictEqual(v.value, 3600000);
+
+        stubbedEnv.DV_HOURS = '2 hours';
+        v = newValue('DV_HOURS');
+        assert.deepStrictEqual(v.value, 7200000);
+
         delete stubbedEnv.DV_HOURS;
       });
 
       it('returns the value if set in days', () => {
-        stubbedEnv.DV_DAYS = '1d';
-        const v = newValue('DV_DAYS');
+        stubbedEnv.DV_DAYS = '2d';
+        let v = newValue('DV_DAYS');
+        assert.deepStrictEqual(v.value, 172800000);
+
+        stubbedEnv.DV_DAYS = '1 day';
+        v = newValue('DV_DAYS');
         assert.deepStrictEqual(v.value, 86400000);
+
+        stubbedEnv.DV_DAYS = '2 days';
+        v = newValue('DV_DAYS');
+        assert.deepStrictEqual(v.value, 172800000);
+
         delete stubbedEnv.DV_DAYS;
       });
 

--- a/tests/values.test.js
+++ b/tests/values.test.js
@@ -310,4 +310,66 @@ describe('values.test.js', () => {
       });
     });
   });
+
+  describe('DurationValue', () => {
+    it('works', () => {
+      new values.DurationValue();
+    });
+
+    describe('.value', () => {
+      function newValue(envName, defaultsTo) {
+        const v = new values.DurationValue(defaultsTo, {envName});
+        return v;
+      }
+
+      it('returns the default correctly', () => {
+        const v = newValue('DOES_NOT_EXIST', 2 * values.DurationValue.MINUTE);
+        assert.deepStrictEqual(v.value, 120000);
+      });
+
+      it('returns the value if there is no unit', () => {
+        let v = newValue('INT');
+        assert.deepStrictEqual(v.value, 23);
+      });
+
+      it('returns the value if set in seconds', () => {
+        stubbedEnv.DV_SECONDS = '4s';
+        const v = newValue('DV_SECONDS');
+        assert.deepStrictEqual(v.value, 4000);
+        delete stubbedEnv.DV_SECONDS;
+      });
+
+      it('returns the value if set in minutes', () => {
+        stubbedEnv.DV_MINUTES = '1m';
+        const v = newValue('DV_MINUTES');
+        assert.deepStrictEqual(v.value, 60000);
+        delete stubbedEnv.DV_MINUTES;
+      });
+
+      it('returns the value if set in hours', () => {
+        stubbedEnv.DV_HOURS = '1h';
+        const v = newValue('DV_HOURS');
+        assert.deepStrictEqual(v.value, 3600000);
+        delete stubbedEnv.DV_HOURS;
+      });
+
+      it('returns the value if set in days', () => {
+        stubbedEnv.DV_DAYS = '1d';
+        const v = newValue('DV_DAYS');
+        assert.deepStrictEqual(v.value, 86400000);
+        delete stubbedEnv.DV_DAYS;
+      });
+
+      it('errors on badly formatted value', () => {
+        stubbedEnv.DURATION = '20x';
+        const v = newValue('DURATION');
+        assert.throws(
+          () => v.value,
+          values.ValueError,
+          'Cannot interpret value.',
+        );
+        delete stubbedEnv.DURATION;
+      });
+    });
+  });
 });


### PR DESCRIPTION
Allows you to set duration settings in the most convenient unit in the environment but still have it resolve to milliseconds in the code.